### PR TITLE
Describe how to use your own certificate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,3 +12,13 @@ If you build it on the system where it will be used and volumes comes from that 
 ```bash
 docker build -t coder --build-arg user_id=$UID --build-arg user_gid=$GID .
 ```
+
+## Run with your own SSL certificate
+Default configuration always run coder with self-signed certificate.
+
+If you have your own certificate you can easily setup it.
+
+Run container with mounted volume where will be your certificate and key and override entrypoint like that:
+```bash
+docker run --name coder -it -v PATH_ON_LOCAL_FILESYSTEM:/home/coder/certs --entrypoint='' coder  code-server --cert=/home/coder/certs/cert_file_name.crt --cert-key=/home/coder/certs/key_filename.key DIRECTORY_IN_CONTAINER_WITH_CODE
+```


### PR DESCRIPTION
Coder runs by default with self-signed certificate so it is save. I add description how to use own certificate.
Fixes #5